### PR TITLE
Add combined multi-tag timeline endpoint

### DIFF
--- a/app/controllers/api/v1/timelines/tags_controller.rb
+++ b/app/controllers/api/v1/timelines/tags_controller.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+class Api::V1::Timelines::TagsController < Api::V1::Timelines::BaseController
+  before_action -> { authorize_if_got_token! :read, :'read:statuses' }
+
+  PERMITTED_PARAMS = %i(local limit only_media remote tags).freeze
+  MAX_TAGS = 100
+
+  def show
+    cache_if_unauthenticated!
+    @statuses = load_statuses
+    render json: @statuses, each_serializer: REST::StatusSerializer, relationships: StatusRelationshipsPresenter.new(@statuses, current_user&.account_id)
+  end
+
+  private
+
+  def require_auth?
+    !Setting.timeline_preview
+  end
+
+  def load_statuses
+    return [] if tag_names.empty?
+
+    raise(Mastodon::ValidationError) if tag_names.size > MAX_TAGS
+
+    preload_collection(tags_timeline_statuses, Status)
+  end
+
+  def tags_timeline_statuses
+    tags_feed.get(
+      limit_param(DEFAULT_STATUSES_LIMIT),
+      params[:max_id],
+      params[:since_id],
+      params[:min_id]
+    )
+  end
+
+  def tags_feed
+    TagsFeed.new(
+      tag_names,
+      current_account,
+      local: truthy_param?(:local),
+      remote: truthy_param?(:remote),
+      only_media: truthy_param?(:only_media)
+    )
+  end
+
+  def tag_names
+    @tag_names ||= Array(params[:tags]).map(&:to_s).compact_blank
+  end
+
+  def permitted_params
+    params.permit(:local, :limit, :only_media, :remote, tags: [])
+  end
+
+  def next_path
+    api_v1_timelines_tags_url next_path_params
+  end
+
+  def prev_path
+    api_v1_timelines_tags_url prev_path_params
+  end
+end

--- a/app/models/tags_feed.rb
+++ b/app/models/tags_feed.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class TagsFeed < PublicFeed
+  # @param [Enumerable<String>] tag_names
+  # @param [Account] account
+  # @param [Hash] options
+  # @option [Boolean] :local
+  # @option [Boolean] :remote
+  # @option [Boolean] :only_media
+  def initialize(tag_names, account, options = {})
+    @tag_names = Array(tag_names)
+    super(account, options)
+  end
+
+  # @param [Integer] limit
+  # @param [Integer] max_id
+  # @param [Integer] since_id
+  # @param [Integer] min_id
+  # @return [Array<Status>]
+  def get(limit, max_id = nil, since_id = nil, min_id = nil)
+    scope = public_scope
+
+    scope.merge!(tagged_with_any_scope)
+    scope.merge!(local_only_scope) if local_only?
+    scope.merge!(remote_only_scope) if remote_only?
+    scope.merge!(account_filters_scope) if account?
+    scope.merge!(media_only_scope) if media_only?
+
+    scope.to_a_paginated_by_id(limit, max_id: max_id, since_id: since_id, min_id: min_id)
+  end
+
+  private
+
+  def tagged_with_any_scope
+    Status.group(:id).tagged_with(tag_ids)
+  end
+
+  def tag_ids
+    Tag.matching_name(@tag_names).pluck(:id) if @tag_names.present?
+  end
+end

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -41,6 +41,7 @@ namespace :api, format: false do
       resource :public, only: :show, controller: :public
       resource :link, only: :show, controller: :link
       resources :tag, only: :show
+      resource :tags, only: :show, controller: :tags
       resources :list, only: :show
     end
 

--- a/spec/requests/api/v1/timelines/tags_spec.rb
+++ b/spec/requests/api/v1/timelines/tags_spec.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Tags' do
+  let(:user)    { Fabricate(:user) }
+  let(:scopes)  { 'read:statuses' }
+  let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
+  let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
+
+  describe 'GET /api/v1/timelines/tags' do
+    subject do
+      get '/api/v1/timelines/tags', headers: headers, params: params
+    end
+
+    shared_examples 'a successful request to the tags timeline' do
+      it 'returns the expected statuses', :aggregate_failures do
+        subject
+
+        expect(response)
+          .to have_http_status(200)
+        expect(response.content_type)
+          .to start_with('application/json')
+        expect(response.parsed_body.pluck(:id))
+          .to match_array(expected_statuses.map { |status| status.id.to_s })
+          .and not_include(private_status.id)
+      end
+    end
+
+    let(:account)         { Fabricate(:account) }
+    let!(:private_status) { PostStatusService.new.call(account, visibility: :private, text: '#life could be a dream') }
+    let!(:life_status)    { PostStatusService.new.call(account, text: 'tell me what is my #life without your #love') }
+    let!(:war_status)     { PostStatusService.new.call(user.account, text: '#war, war never changes') }
+    let!(:love_status)    { PostStatusService.new.call(account, text: 'what is #love?') }
+    let!(:peace_status)   { PostStatusService.new.call(account, text: 'give #peace a chance') }
+    let!(:hope_status)    { PostStatusService.new.call(account, text: 'a little #hope') }
+    let!(:joy_status)     { PostStatusService.new.call(account, text: 'pure #joy') }
+    let(:params)          { {} }
+
+    it_behaves_like 'forbidden for wrong scope', 'profile'
+
+    context 'when given a single tag' do
+      let(:expected_statuses) { [life_status] }
+      let(:params)            { { tags: %w(life) } }
+
+      it_behaves_like 'a successful request to the tags timeline'
+    end
+
+    context 'when given multiple tags' do
+      let(:expected_statuses) { [life_status, love_status, war_status] }
+      let(:params)            { { tags: %w(life love war) } }
+
+      it_behaves_like 'a successful request to the tags timeline'
+    end
+
+    context 'when given more than four tags' do
+      let(:expected_statuses) { [life_status, love_status, war_status, peace_status, hope_status, joy_status] }
+      let(:params)            { { tags: %w(life love war peace hope joy) } }
+
+      it_behaves_like 'a successful request to the tags timeline'
+    end
+
+    context 'when no tags are given' do
+      let(:params) { {} }
+
+      it 'returns an empty array' do
+        subject
+
+        expect(response).to have_http_status(200)
+        expect(response.parsed_body).to eq([])
+      end
+    end
+
+    context 'with blank tag values' do
+      let(:params) { { tags: ['', '  '] } }
+
+      it 'returns an empty array' do
+        subject
+
+        expect(response).to have_http_status(200)
+        expect(response.parsed_body).to eq([])
+      end
+    end
+
+    context 'when given more than the maximum number of tags' do
+      let(:params) { { tags: Array.new(101) { |i| "tag#{i}" } } }
+
+      it 'returns http unprocessable entity' do
+        subject
+
+        expect(response).to have_http_status(422)
+        expect(response.content_type)
+          .to start_with('application/json')
+      end
+    end
+
+    context 'with limit param' do
+      let(:params) { { tags: %w(life love), limit: 1 } }
+
+      it 'returns only the requested number of statuses' do
+        subject
+
+        expect(response.parsed_body.size).to eq(params[:limit])
+      end
+
+      it 'sets the correct pagination headers, preserving tags', :aggregate_failures do
+        subject
+
+        expect(response)
+          .to include_pagination_headers(
+            prev: api_v1_timelines_tags_url(limit: params[:limit], min_id: love_status.id, tags: %w(life love)),
+            next: api_v1_timelines_tags_url(limit: params[:limit], max_id: love_status.id, tags: %w(life love))
+          )
+        expect(response.content_type)
+          .to start_with('application/json')
+      end
+    end
+
+    context 'when the instance allows public preview' do
+      context 'when the user is not authenticated' do
+        let(:headers)           { {} }
+        let(:expected_statuses) { [life_status] }
+        let(:params)            { { tags: %w(life) } }
+
+        it_behaves_like 'a successful request to the tags timeline'
+      end
+    end
+
+    context 'when the instance does not allow public preview' do
+      before do
+        Form::AdminSettings.new(timeline_preview: false).save
+      end
+
+      it_behaves_like 'forbidden for wrong scope', 'profile'
+
+      context 'without an authentication token' do
+        let(:headers) { {} }
+        let(:params)  { { tags: %w(life) } }
+
+        it 'returns http unprocessable entity' do
+          subject
+
+          expect(response).to have_http_status(422)
+          expect(response.content_type)
+            .to start_with('application/json')
+        end
+      end
+
+      context 'when the user is authenticated' do
+        let(:expected_statuses) { [life_status] }
+        let(:params)            { { tags: %w(life) } }
+
+        it_behaves_like 'a successful request to the tags timeline'
+      end
+    end
+  end
+end

--- a/zai-bitnami.Dockerfile
+++ b/zai-bitnami.Dockerfile
@@ -10,6 +10,11 @@ COPY app/controllers/api/v1/internal /opt/bitnami/mastodon/app/controllers/api/v
 COPY app/services/internal /opt/bitnami/mastodon/app/services/internal
 COPY config/routes/api.rb /opt/bitnami/mastodon/config/routes/api.rb
 
+# Copy multi-tag timeline endpoint
+COPY app/models/tags_feed.rb /opt/bitnami/mastodon/app/models/tags_feed.rb
+COPY spec/requests/api/v1/timelines/tags_spec.rb /opt/bitnami/mastodon/spec/requests/api/v1/timelines/tags_spec.rb
+COPY app/controllers/api/v1/timelines/tags_controller.rb /opt/bitnami/mastodon/app/controllers/api/v1/timelines/tags_controller.rb
+
 USER 1001
 ENTRYPOINT [ "/opt/bitnami/scripts/mastodon/entrypoint.sh" ]
 CMD [ "/opt/bitnami/scripts/mastodon/run.sh" ]


### PR DESCRIPTION
## What

Adds `GET /api/v1/timelines/tags` — returns the **union timeline of a client-supplied list of hashtags**, with no predefined server-side list and no single anchor tag. Enables a client-defined "supertag" (a set of tags shown as one timeline).

```
GET /api/v1/timelines/tags?tags[]=coffee&tags[]=espresso&tags[]=latte
```

## Why

The existing tag timeline (`GET /api/v1/timelines/tag/:id?any[]=...`) already combines tags, but:
- requires **one anchor tag** in the URL path, and
- silently caps each mode at **4 tags** (`TagFeed::LIMIT_PER_MODE`).

This endpoint takes a flat `tags[]` list, applies **no per-tag cap** (guarded by a `MAX_TAGS = 100` ceiling → `422` above it), and needs no anchor.

## Design / reuse

`TagsFeed` is the reusable core — it takes a plain list of tag **names** (not controller params), so a future supertag endpoint can resolve a supertag id → tag names and drive the **same** feed with zero query duplication. It subclasses `PublicFeed`, reusing `public_scope`, the `local`/`remote`/`only_media` filters, and `to_a_paginated_by_id` pagination. Auth mirrors the tag endpoint (`authorize_if_got_token!`, public preview when the instance allows).

## Params

`tags[]` (union), `local`, `remote`, `only_media`, `limit`, `max_id`, `since_id`, `min_id`. Empty/missing `tags[]` → `[]`.

## Testing

New request spec `spec/requests/api/v1/timelines/tags_spec.rb`: union, >4 tags (cap gone), empty, blank, 101-tag → 422, limit + pagination headers (preserving `tags[]`), auth/preview cases.

Also verified live against a dev instance (real DB + OAuth token), 19 assertions: dedup (post with 2 matching tags counts once), visibility exclusion (private/unlisted/direct), case normalization (`ZTEA` == `ztea`), multi-author, mixed real/fake tags, id-desc ordering, full pagination walk over 25 posts via `max_id`, `min_id`, and `local`/`remote`/`only_media` filters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)