### PR TITLE
Make multi-tag timeline a POST to avoid oversized Link header (502)

### DIFF
--- a/app/controllers/api/v1/timelines/tags_controller.rb
+++ b/app/controllers/api/v1/timelines/tags_controller.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
 class Api::V1::Timelines::TagsController < Api::V1::Timelines::BaseController
+  # Tags are supplied in the request body (POST), so no pagination Link header
+  # is emitted: clients paginate with max_id/since_id/min_id in the body.
+  skip_after_action :insert_pagination_headers
+
   before_action -> { authorize_if_got_token! :read, :'read:statuses' }
 
-  PERMITTED_PARAMS = %i(local limit only_media remote tags).freeze
   MAX_TAGS = 100
 
   def show
@@ -21,7 +24,7 @@ class Api::V1::Timelines::TagsController < Api::V1::Timelines::BaseController
   def load_statuses
     return [] if tag_names.empty?
 
-    raise(Mastodon::ValidationError) if tag_names.size > MAX_TAGS
+    raise Mastodon::ValidationError, "Too many tags (maximum is #{MAX_TAGS})" if tag_names.size > MAX_TAGS
 
     preload_collection(tags_timeline_statuses, Status)
   end
@@ -47,17 +50,5 @@ class Api::V1::Timelines::TagsController < Api::V1::Timelines::BaseController
 
   def tag_names
     @tag_names ||= Array(params[:tags]).map(&:to_s).compact_blank
-  end
-
-  def permitted_params
-    params.permit(:local, :limit, :only_media, :remote, tags: [])
-  end
-
-  def next_path
-    api_v1_timelines_tags_url next_path_params
-  end
-
-  def prev_path
-    api_v1_timelines_tags_url prev_path_params
   end
 end

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -41,7 +41,7 @@ namespace :api, format: false do
       resource :public, only: :show, controller: :public
       resource :link, only: :show, controller: :link
       resources :tag, only: :show
-      resource :tags, only: :show, controller: :tags
+      post :tags, to: 'tags#show'
       resources :list, only: :show
     end
 

--- a/spec/requests/api/v1/timelines/tags_spec.rb
+++ b/spec/requests/api/v1/timelines/tags_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe 'Tags' do
   let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
   let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
 
-  describe 'GET /api/v1/timelines/tags' do
+  describe 'POST /api/v1/timelines/tags' do
     subject do
-      get '/api/v1/timelines/tags', headers: headers, params: params
+      post '/api/v1/timelines/tags', headers: headers, params: params
     end
 
     shared_examples 'a successful request to the tags timeline' do
@@ -103,16 +103,22 @@ RSpec.describe 'Tags' do
         expect(response.parsed_body.size).to eq(params[:limit])
       end
 
-      it 'sets the correct pagination headers, preserving tags', :aggregate_failures do
+      it 'does not set a pagination Link header' do
         subject
 
-        expect(response)
-          .to include_pagination_headers(
-            prev: api_v1_timelines_tags_url(limit: params[:limit], min_id: love_status.id, tags: %w(life love)),
-            next: api_v1_timelines_tags_url(limit: params[:limit], max_id: love_status.id, tags: %w(life love))
-          )
-        expect(response.content_type)
-          .to start_with('application/json')
+        expect(response.headers['Link']).to be_nil
+      end
+    end
+
+    context 'with max_id param' do
+      let(:params) { { tags: %w(life love), max_id: love_status.id } }
+
+      it 'returns only statuses older than max_id', :aggregate_failures do
+        subject
+
+        ids = response.parsed_body.pluck(:id)
+        expect(ids).to include(life_status.id.to_s)
+        expect(ids).to_not include(love_status.id.to_s)
       end
     end
 


### PR DESCRIPTION
## Problem

`GET /api/v1/timelines/tags` (added in #4) returned **502 Bad Gateway** in production when given a large tag list (e.g. 36 tags).

Root cause — traced with prod nginx logs + local reproduction: the endpoint echoed the **full tag list into the pagination `Link` header** (both `next` and `prev` URLs). For 36 tags that header was **~4.8 KB**, exceeding nginx's default upstream response-header buffer (`proxy_buffer_size` = 4 KB). nginx rejected the upstream response with *"upstream sent too big header"* → **502**, 0 upstream bytes, ~0.29s. It only surfaced on **non-empty** results, because Mastodon omits the `Link` header when the result is empty (which is why it passed every test with an empty local DB).

It was never the DB, query cost, URL length, or Arabic characters — puma serves the request 200; the reverse proxy rejects the oversized **response header**.

## Fix

Move the tag list (and all params) into the **request body** via `POST`, and drop the pagination `Link` header (`skip_after_action :insert_pagination_headers`). Clients paginate by sending `max_id` in the body, keyed off the last returned status id.

This bounds the response header size regardless of tag count (measured: **5824 -> 1003 bytes** for the exact failing 36-tag request) and removes any request URL-length ceiling for large supertags.

The feed itself is unchanged: `TagsFeed`, the `MAX_TAGS = 100` ceiling, and the `local`/`remote`/`only_media` filters are identical. The reusable `TagsFeed` core (for a future supertag endpoint) is untouched.

## API change

```http
POST /api/v1/timelines/tags
Content-Type: application/json

{ "tags": ["coffee","espresso","latte"], "limit": 20, "max_id": "..." }
```

- Body params: `tags[]` (union), `local`, `remote`, `only_media`, `max_id`, `since_id`, `min_id`, `limit`.
- No `Link` header — paginate client-side via `max_id`.

## Testing

- Request spec updated to `POST`; asserts no `Link` header and correct `max_id` pagination. All own-logic examples pass (the 2 unauthenticated failures are the pre-existing `limited_federation_mode` env behaviour, identical to the upstream `tag` spec).
- Reproduced the exact 36-Arabic-tag request locally against a non-empty result: previously 5824-byte response header (4836-byte `Link`); now **200, no `Link` header, 1003-byte header block**.
- Rubocop clean.