### PR TITLE
Add interests: curated tag groupings with per-interest, personal, and internal APIs

### DIFF
--- a/app/controllers/api/v1/interests/tags_controller.rb
+++ b/app/controllers/api/v1/interests/tags_controller.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+class Api::V1::Interests::TagsController < Api::BaseController
+  TAGS_LIMIT = 100
+
+  before_action -> { authorize_if_got_token! :read }
+  before_action :set_interest
+  before_action :set_results
+
+  after_action :insert_pagination_headers
+
+  # Paginates on interest_tags.id (insertion order) rather than tag id, so the
+  # standard id-cursor helper applies unchanged. Cursor ids are opaque to
+  # clients, which is already the contract for Mastodon pagination.
+  def index
+    cache_if_unauthenticated!
+    render json: @results.map(&:tag), each_serializer: REST::TagSerializer, relationships: TagRelationshipsPresenter.new(@results.map(&:tag), current_user&.account_id)
+  end
+
+  private
+
+  def set_interest
+    @interest = Interest.find_normalized(params[:name]) || not_found
+  end
+
+  def set_results
+    @results = InterestTag.where(interest_id: @interest.id).joins(:tag).eager_load(:tag).to_a_paginated_by_id(
+      limit_param(TAGS_LIMIT),
+      params_slice(:max_id, :since_id, :min_id)
+    )
+  end
+
+  def next_path
+    api_v1_interest_tags_url params[:name], pagination_params(max_id: pagination_max_id) if records_continue?
+  end
+
+  def prev_path
+    api_v1_interest_tags_url params[:name], pagination_params(since_id: pagination_since_id) unless @results.empty?
+  end
+
+  def pagination_collection
+    @results
+  end
+
+  def records_continue?
+    @results.size == limit_param(TAGS_LIMIT)
+  end
+end

--- a/app/controllers/api/v1/interests_controller.rb
+++ b/app/controllers/api/v1/interests_controller.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+class Api::V1::InterestsController < Api::BaseController
+  before_action -> { authorize_if_got_token! :read }, only: :index
+  before_action -> { doorkeeper_authorize! :read, :'read:accounts' }, only: :me
+  before_action -> { doorkeeper_authorize! :write, :'write:accounts' }, only: :update_me
+  before_action :require_user!, only: [:me, :update_me]
+
+  # The interest taxonomy is curated and small (tens of entries), so the full
+  # list is returned unpaginated. Recency ordering is also incompatible with
+  # to_a_paginated_by_id, which cursors on the record's own id.
+  def index
+    cache_if_unauthenticated!
+    render_interests(Interest.all)
+  end
+
+  def me
+    render_interests(current_account.interests)
+  end
+
+  # Replace-set: the client sends the final desired state. An empty array clears
+  # every interest. Unknown names change nothing and return 422, because
+  # interests are server-curated and the client fetches them from #index, so an
+  # unknown name is always a client bug rather than user input.
+  def update_me
+    normalized = requested_names.index_with { |name| Interest.normalize(name) }
+    found      = Interest.matching_name(normalized.values.uniq).index_by(&:name)
+    unknown    = requested_names.reject { |name| found.key?(normalized[name]) }.uniq
+
+    return render json: { error: 'Unknown interests', unknown: unknown }, status: 422 if unknown.any?
+
+    replace_interests!(found.values.map(&:id))
+
+    render_interests(current_account.interests.reload)
+  end
+
+  private
+
+  def requested_names
+    @requested_names ||= Array(params[:interests]).map(&:to_s).compact_blank.uniq
+  end
+
+  def replace_interests!(interest_ids)
+    ApplicationRecord.transaction do
+      current_account.account_interests.where.not(interest_id: interest_ids).delete_all
+
+      existing = current_account.account_interests.pluck(:interest_id)
+      rows     = (interest_ids - existing).map do |interest_id|
+        { account_id: current_account.id, interest_id: interest_id, created_at: Time.now.utc, updated_at: Time.now.utc }
+      end
+
+      AccountInterest.insert_all(rows, unique_by: [:account_id, :interest_id]) if rows.any?
+    end
+  end
+
+  def render_interests(scope)
+    interests = scope.to_a
+    presenter = InterestsPresenter.new(interests)
+
+    render json: sort_by_recency(interests, presenter), each_serializer: REST::InterestSerializer, presenter: presenter
+  end
+
+  # Most recently active first, name as the tiebreaker. Interests whose tags
+  # have no statuses sort last.
+  def sort_by_recency(interests, presenter)
+    interests.sort_by { |interest| [-(presenter.last_status_ids[interest.id] || 0), interest.name] }
+  end
+end

--- a/app/controllers/api/v1/internal/interests_controller.rb
+++ b/app/controllers/api/v1/internal/interests_controller.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+class Api::V1::Internal::InterestsController < Api::V1::Internal::BaseController
+  MAX_BULK_ASSIGNMENTS = 1_000
+  MAX_TAGS_IN_RESPONSE = 5_000
+
+  def create
+    return render_invalid_name(:interest, params[:interest]) unless valid_name?(params[:interest])
+    return render_invalid_name(:tag, params[:tag]) unless valid_name?(params[:tag])
+
+    interest_name = normalize(params[:interest])
+    tag_name      = normalize(params[:tag])
+
+    interest, interest_created = find_or_create_interest(interest_name)
+    tag, tag_created           = find_or_create_tag(tag_name)
+
+    return render_invalid_name(:tag, params[:tag]) if tag.nil?
+
+    assignment_created = create_assignment(interest, tag)
+
+    log_internal_action(:assign_tag_to_interest, interest)
+
+    render json: {
+      interest: interest.name,
+      interest_id: interest.id.to_s,
+      tag: tag.name,
+      tag_id: tag.id.to_s,
+      interest_created: interest_created,
+      tag_created: tag_created,
+      assignment_created: assignment_created,
+    }, status: assignment_created ? 201 : 200
+  end
+
+  def destroy
+    return render_invalid_name(:interest, params[:interest]) unless valid_name?(params[:interest])
+    return render_invalid_name(:tag, params[:tag]) unless valid_name?(params[:tag])
+
+    interest_name = normalize(params[:interest])
+    tag_name      = normalize(params[:tag])
+
+    interest = Interest.find_normalized(interest_name)
+    tag      = Tag.find_normalized(tag_name)
+    deleted  = false
+
+    if interest.present? && tag.present?
+      deleted = InterestTag.where(interest_id: interest.id, tag_id: tag.id).delete_all.positive?
+      log_internal_action(:unassign_tag_from_interest, interest) if deleted
+    end
+
+    render json: { interest: interest_name, tag: tag_name, deleted: deleted }, status: 200
+  end
+
+  def bulk
+    assignments = params[:assignments]
+
+    return render json: { error: 'assignments must be an array' }, status: 422 unless assignments.is_a?(Array)
+    return render json: { error: "Too many assignments (maximum is #{MAX_BULK_ASSIGNMENTS})" }, status: 422 if assignments.size > MAX_BULK_ASSIGNMENTS
+
+    result = Internal::AssignTagsToInterestsService.new.call(assignments)
+
+    Rails.logger.info("[Internal API] Action: bulk_assign_tags_to_interests, Count: #{result[:assignments_created]}, IP: #{request.remote_ip}")
+
+    render json: result, status: 200
+  end
+
+  def tags
+    interest = Interest.find_normalized(params[:name])
+
+    return render json: { error: 'Interest not found' }, status: 404 if interest.nil?
+
+    tags_count = interest.interest_tags.count
+
+    if tags_count > MAX_TAGS_IN_RESPONSE
+      return render json: {
+        error: "Interest has too many tags for an unpaginated response (maximum is #{MAX_TAGS_IN_RESPONSE}), use GET /api/v1/interests/:name/tags",
+        tags_count: tags_count,
+      }, status: 422
+    end
+
+    render json: {
+      interest: interest.name,
+      interest_id: interest.id.to_s,
+      tags_count: tags_count,
+      tags: interest.tags.pluck(:name),
+    }, status: 200
+  end
+
+  private
+
+  def normalize(value)
+    Interest.normalize(value.to_s)
+  end
+
+  # Validates the RAW input, not the normalized form: HashtagNormalizer strips
+  # invalid characters, so "not a tag!" would normalize to a perfectly valid
+  # "notatag" and nothing would ever be rejected. Same approach as
+  # Api::V1::TagsController#set_or_create_tag.
+  #
+  # This has to happen before any create because Tag.find_or_create_by_names
+  # uses `create`, not `create!`: an invalid name silently returns an unpersisted
+  # record whose nil id would then violate interest_tags.tag_id NOT NULL.
+  def valid_name?(raw_name)
+    raw_name.present? && Tag::HASHTAG_NAME_RE.match?(raw_name.to_s)
+  end
+
+  def render_invalid_name(kind, value)
+    render json: { error: "Invalid #{kind} name" }.merge(kind => value), status: 422
+  end
+
+  def find_or_create_interest(name)
+    interest = Interest.find_normalized(name)
+    return [interest, false] if interest.present?
+
+    [Interest.create!(name: name), true]
+  rescue ActiveRecord::RecordNotUnique
+    [Interest.find_normalized(name), false]
+  end
+
+  def find_or_create_tag(name)
+    tag = Tag.find_normalized(name)
+    return [tag, false] if tag.present?
+
+    tag = Tag.find_or_create_by_names(name).first
+    tag&.persisted? ? [tag, true] : [nil, false]
+  end
+
+  def create_assignment(interest, tag)
+    InterestTag.create!(interest: interest, tag: tag)
+    true
+  rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid
+    false
+  end
+end

--- a/app/controllers/api/v1/timelines/interest_controller.rb
+++ b/app/controllers/api/v1/timelines/interest_controller.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+class Api::V1::Timelines::InterestController < Api::V1::Timelines::BaseController
+  before_action -> { authorize_if_got_token! :read, :'read:statuses' }
+  before_action :load_interest
+
+  PERMITTED_PARAMS = %i(local limit only_media remote).freeze
+
+  # Unlike the multi-tag timeline this can stay a GET: only one short interest
+  # name goes into the URL, so the pagination Link header stays small and
+  # standard next/prev links keep working.
+  def show
+    cache_if_unauthenticated!
+    @statuses = load_statuses
+    render json: @statuses, each_serializer: REST::StatusSerializer, relationships: StatusRelationshipsPresenter.new(@statuses, current_user&.account_id)
+  end
+
+  private
+
+  def require_auth?
+    !Setting.timeline_preview
+  end
+
+  def load_interest
+    @interest = Interest.find_normalized(params[:id]) || not_found
+  end
+
+  def load_statuses
+    return [] if tag_ids.empty?
+
+    preload_collection(interest_timeline_statuses, Status)
+  end
+
+  # No tag-count cap here. Api::V1::Timelines::TagsController::MAX_TAGS bounds
+  # untrusted client input; an interest is a server-curated set and is trusted.
+  def interest_timeline_statuses
+    interest_feed.get(
+      limit_param(DEFAULT_STATUSES_LIMIT),
+      params[:max_id],
+      params[:since_id],
+      params[:min_id]
+    )
+  end
+
+  def interest_feed
+    TagsFeed.new(
+      nil,
+      current_account,
+      tag_ids: tag_ids,
+      local: truthy_param?(:local),
+      remote: truthy_param?(:remote),
+      only_media: truthy_param?(:only_media)
+    )
+  end
+
+  def tag_ids
+    @tag_ids ||= @interest.tag_ids
+  end
+
+  def next_path
+    api_v1_timelines_interest_url params[:id], next_path_params
+  end
+
+  def prev_path
+    api_v1_timelines_interest_url params[:id], prev_path_params
+  end
+end

--- a/app/controllers/api/v1/timelines/interests_controller.rb
+++ b/app/controllers/api/v1/timelines/interests_controller.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# Personal interest feed: the union timeline of every tag in every interest the
+# authenticated account has selected. A live query, so a brand-new account gets a
+# populated feed on the first request without any home-feed fan-out or backfill.
+class Api::V1::Timelines::InterestsController < Api::V1::Timelines::BaseController
+  before_action -> { doorkeeper_authorize! :read, :'read:statuses' }
+  before_action :require_user!
+
+  PERMITTED_PARAMS = %i(local limit only_media remote).freeze
+
+  def show
+    with_read_replica do
+      @statuses      = load_statuses
+      @relationships = StatusRelationshipsPresenter.new(@statuses, current_user&.account_id)
+    end
+
+    render json: @statuses, each_serializer: REST::StatusSerializer, relationships: @relationships
+  end
+
+  private
+
+  def load_statuses
+    return [] if tag_ids.empty?
+
+    preload_collection(interest_timeline_statuses, Status)
+  end
+
+  def interest_timeline_statuses
+    interest_feed.get(
+      limit_param(DEFAULT_STATUSES_LIMIT),
+      params[:max_id],
+      params[:since_id],
+      params[:min_id]
+    )
+  end
+
+  def interest_feed
+    TagsFeed.new(
+      nil,
+      current_account,
+      tag_ids: tag_ids,
+      local: truthy_param?(:local),
+      remote: truthy_param?(:remote),
+      only_media: truthy_param?(:only_media)
+    )
+  end
+
+  def tag_ids
+    @tag_ids ||= InterestTag.where(interest_id: current_account.interest_ids).distinct.pluck(:tag_id)
+  end
+
+  def next_path
+    api_v1_timelines_interests_url next_path_params
+  end
+
+  def prev_path
+    api_v1_timelines_interests_url prev_path_params
+  end
+end

--- a/app/models/account_interest.rb
+++ b/app/models/account_interest.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: account_interests
+#
+#  id          :bigint(8)        not null, primary key
+#  account_id  :bigint(8)        not null
+#  interest_id :bigint(8)        not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+
+class AccountInterest < ApplicationRecord
+  include Paginable
+
+  belongs_to :account
+  belongs_to :interest
+
+  validates :interest_id, uniqueness: { scope: :account_id }
+
+  scope :for_local_distribution, -> { joins(account: :user).merge(User.signed_in_recently) }
+end

--- a/app/models/concerns/account/associations.rb
+++ b/app/models/concerns/account/associations.rb
@@ -8,6 +8,7 @@ module Account::Associations
     with_options dependent: :destroy do
       # Association where account owns record
       with_options inverse_of: :account do
+        has_many :account_interests
         has_many :account_moderation_notes
         has_many :account_pins
         has_many :account_warnings
@@ -55,6 +56,9 @@ module Account::Associations
 
     # List records the account has been added to (not owned by the account)
     has_many :lists, through: :list_accounts
+
+    # Interest records the account has selected
+    has_many :interests, through: :account_interests
 
     # Account record where account has been migrated
     belongs_to :moved_to_account, class_name: 'Account', optional: true

--- a/app/models/interest.rb
+++ b/app/models/interest.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: interests
+#
+#  id         :bigint(8)        not null, primary key
+#  name       :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+class Interest < ApplicationRecord
+  include Paginable
+
+  has_many :interest_tags, inverse_of: :interest, dependent: :destroy
+  has_many :tags, through: :interest_tags
+
+  has_many :account_interests, inverse_of: :interest, dependent: :destroy
+  has_many :accounts, through: :account_interests
+
+  before_validation :normalize_name
+
+  validates :name, presence: true, format: { with: Tag::HASHTAG_NAME_RE }
+  validates :name, uniqueness: { case_sensitive: false }
+
+  class << self
+    def matching_name(name_or_names)
+      names = Array(name_or_names).map { |name| arel_table.lower(normalize(name)) }
+
+      if names.size == 1
+        where(arel_table[:name].lower.eq(names.first))
+      else
+        where(arel_table[:name].lower.in(names))
+      end
+    end
+
+    def find_normalized(name)
+      matching_name(name).first
+    end
+
+    def find_normalized!(name)
+      find_normalized(name) || raise(ActiveRecord::RecordNotFound)
+    end
+
+    # Interest names follow the same normalization rules as hashtags, so that
+    # the classifier does not need to know about them and casing differences
+    # cannot produce duplicate interests.
+    def normalize(str)
+      Tag.normalize(str)
+    end
+  end
+
+  private
+
+  def normalize_name
+    self.name = self.class.normalize(name) if name.present?
+  end
+end

--- a/app/models/interest_tag.rb
+++ b/app/models/interest_tag.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: interest_tags
+#
+#  id          :bigint(8)        not null, primary key
+#  interest_id :bigint(8)        not null
+#  tag_id      :bigint(8)        not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+
+class InterestTag < ApplicationRecord
+  include Paginable
+
+  belongs_to :interest
+  belongs_to :tag
+
+  validates :tag_id, uniqueness: { scope: :interest_id }
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -28,6 +28,9 @@ class Tag < ApplicationRecord
   has_and_belongs_to_many :accounts
   # rubocop:enable Rails/HasAndBelongsToMany
 
+  has_many :interest_tags, inverse_of: :tag, dependent: :destroy
+  has_many :interests, through: :interest_tags
+
   has_many :passive_relationships, class_name: 'TagFollow', inverse_of: :tag, dependent: :destroy
   has_many :featured_tags, dependent: :destroy, inverse_of: :tag
   has_many :followers, through: :passive_relationships, source: :account

--- a/app/models/tags_feed.rb
+++ b/app/models/tags_feed.rb
@@ -1,14 +1,17 @@
 # frozen_string_literal: true
 
 class TagsFeed < PublicFeed
-  # @param [Enumerable<String>] tag_names
+  # @param [Enumerable<String>, nil] tag_names Ignored when :tag_ids is given
   # @param [Account] account
   # @param [Hash] options
+  # @option [Enumerable<Integer>] :tag_ids Pre-resolved tag ids, skips the name lookup
   # @option [Boolean] :local
   # @option [Boolean] :remote
   # @option [Boolean] :only_media
   def initialize(tag_names, account, options = {})
+    options    = options.dup
     @tag_names = Array(tag_names)
+    @tag_ids   = options.delete(:tag_ids)&.to_a
     super(account, options)
   end
 
@@ -36,6 +39,6 @@ class TagsFeed < PublicFeed
   end
 
   def tag_ids
-    Tag.matching_name(@tag_names).pluck(:id) if @tag_names.present?
+    @tag_ids ||= (Tag.matching_name(@tag_names).pluck(:id) if @tag_names.present?)
   end
 end

--- a/app/presenters/interests_presenter.rb
+++ b/app/presenters/interests_presenter.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+# Batch-loads the derived attributes of a set of interests in a constant number
+# of queries, so serializing N interests never becomes N+1.
+class InterestsPresenter
+  attr_reader :tags_counts, :last_status_ids
+
+  # @param [Enumerable<Interest>] interests
+  def initialize(interests)
+    @interest_ids    = interests.map(&:id)
+    @tags_counts     = load_tags_counts
+    @last_status_ids = load_last_status_ids
+  end
+
+  def tags_count(interest_id)
+    @tags_counts[interest_id] || 0
+  end
+
+  # @return [Time, nil]
+  def last_status_at(interest_id)
+    status_id = @last_status_ids[interest_id]
+
+    status_id && Mastodon::Snowflake.to_time(status_id)
+  end
+
+  private
+
+  def load_tags_counts
+    return {} if @interest_ids.empty?
+
+    InterestTag.where(interest_id: @interest_ids).group(:interest_id).count
+  end
+
+  # Recency is derived from MAX(statuses_tags.status_id): Mastodon ids are
+  # Snowflake, so the largest id is the most recent status.
+  #
+  # tags.last_status_at is unusable for this - it is only written for remote
+  # statuses (app/lib/activitypub/activity/create.rb) and throttled to once per
+  # 12 hours, so locally authored posts never update it.
+  #
+  # The lateral is what keeps this cheap: statuses_tags has primary key
+  # (tag_id, status_id), so each interest_tags row costs one backwards index
+  # seek with LIMIT 1. Cost is bounded by the size of the taxonomy rather than
+  # by the number of statuses, and the statuses table is never touched.
+  def load_last_status_ids
+    return {} if @interest_ids.empty?
+
+    binds = [
+      ActiveRecord::Relation::QueryAttribute.new('interest_ids', @interest_ids, ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Array.new(ActiveModel::Type::BigInteger.new)),
+    ]
+
+    ActiveRecord::Base.connection.select_all(<<~SQL.squish, 'interest_last_status_ids', binds).cast_values.to_h
+      SELECT it.interest_id, MAX(l.status_id)
+      FROM interest_tags it
+      CROSS JOIN LATERAL (
+        SELECT st.status_id
+        FROM statuses_tags st
+        WHERE st.tag_id = it.tag_id
+        ORDER BY st.status_id DESC
+        LIMIT 1
+      ) l
+      WHERE it.interest_id = ANY($1)
+      GROUP BY it.interest_id
+    SQL
+  end
+end

--- a/app/serializers/rest/interest_serializer.rb
+++ b/app/serializers/rest/interest_serializer.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class REST::InterestSerializer < ActiveModel::Serializer
+  attributes :id, :name, :tags_count, :last_status_at
+
+  def id
+    object.id.to_s
+  end
+
+  def tags_count
+    presenter.tags_count(object.id)
+  end
+
+  def last_status_at
+    presenter.last_status_at(object.id)&.iso8601
+  end
+
+  private
+
+  def presenter
+    instance_options[:presenter]
+  end
+end

--- a/app/services/internal/assign_tags_to_interests_service.rb
+++ b/app/services/internal/assign_tags_to_interests_service.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+# Bulk-assigns tags to interests, creating either as needed.
+#
+# Deliberately NOT transactional: one malformed name must not roll back the rest
+# of the batch. Invalid entries are reported per-index and everything else is
+# committed.
+class Internal::AssignTagsToInterestsService < BaseService
+  # @param [Enumerable<Hash>] assignments Entries of { interest:, tag: }
+  # @return [Hash]
+  def call(assignments)
+    @errors = []
+
+    pairs = normalize_pairs(assignments)
+
+    interests, interests_created = resolve_interests(pairs.map(&:first).uniq)
+    tags, tags_created           = resolve_tags(pairs.map(&:last).uniq)
+
+    {
+      processed: assignments.size,
+      assignments_created: insert_assignments(pairs, interests, tags),
+      interests_created: interests_created,
+      tags_created: tags_created,
+      errors: @errors,
+    }
+  end
+
+  private
+
+  # @return [Array<Array(String, String)>] valid [interest_name, tag_name] pairs
+  def normalize_pairs(assignments)
+    assignments.filter_map.with_index do |assignment, index|
+      # String responds to :[] too, so key? is the check that actually excludes scalars
+      next add_error(index, {}, 'Assignment must be an object') unless assignment.respond_to?(:key?)
+
+      next add_error(index, assignment, 'Invalid interest name') unless valid_name?(assignment[:interest])
+      next add_error(index, assignment, 'Invalid tag name') unless valid_name?(assignment[:tag])
+
+      [Interest.normalize(assignment[:interest].to_s), Interest.normalize(assignment[:tag].to_s)]
+    end.uniq
+  end
+
+  # Validates the RAW input, not the normalized form: HashtagNormalizer strips
+  # invalid characters, so "not a tag!" would normalize to a valid "notatag" and
+  # nothing would ever be rejected.
+  #
+  # This has to happen before any create because Tag.find_or_create_by_names
+  # uses `create`, not `create!`: an invalid name silently returns an unpersisted
+  # record whose nil id would then violate interest_tags.tag_id NOT NULL.
+  def valid_name?(raw_name)
+    raw_name.present? && Tag::HASHTAG_NAME_RE.match?(raw_name.to_s)
+  end
+
+  def add_error(index, assignment, message)
+    @errors << { index: index, interest: assignment[:interest], tag: assignment[:tag], error: message }
+    nil
+  end
+
+  # @return [Array(Hash<String, Integer>, Integer)] name => id, and created count
+  def resolve_interests(names)
+    return [{}, 0] if names.empty?
+
+    existing = Interest.matching_name(names).pluck(:name, :id).to_h
+    missing  = names - existing.keys
+
+    return [existing, 0] if missing.empty?
+
+    # Interests are a curated taxonomy in the tens, so a per-row create is fine
+    # here and avoids insert_all's poor handling of the lower(name) expression index.
+    created = missing.filter_map do |name|
+      Interest.create!(name: name)
+    rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid
+      nil
+    end
+
+    [Interest.matching_name(names).pluck(:name, :id).to_h, created.size]
+  end
+
+  # @return [Array(Hash<String, Integer>, Integer)] name => id, and created count
+  def resolve_tags(names)
+    return [{}, 0] if names.empty?
+
+    existing = Tag.matching_name(names).pluck(:name, :id).to_h
+    missing  = names - existing.keys
+
+    return [existing, 0] if missing.empty?
+
+    created = Tag.find_or_create_by_names(missing).select(&:persisted?)
+
+    [existing.merge(created.to_h { |tag| [tag.name, tag.id] }), created.size]
+  end
+
+  def insert_assignments(pairs, interests, tags)
+    rows = pairs.filter_map do |(interest_name, tag_name)|
+      interest_id = interests[interest_name]
+      tag_id      = tags[tag_name]
+
+      next if interest_id.nil? || tag_id.nil?
+
+      { interest_id: interest_id, tag_id: tag_id, created_at: Time.now.utc, updated_at: Time.now.utc }
+    end
+
+    return 0 if rows.empty?
+
+    InterestTag.insert_all(rows, unique_by: [:interest_id, :tag_id], returning: [:id]).length
+  end
+end

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -42,6 +42,7 @@ namespace :api, format: false do
       resource :link, only: :show, controller: :link
       resources :tag, only: :show
       post :tags, to: 'tags#show'
+      resources :interest, only: :show
       resources :list, only: :show
     end
 
@@ -217,6 +218,13 @@ namespace :api, format: false do
       end
     end
 
+    # `interests/me` is declared first so the literal always wins over a future
+    # `interests/:name` route ("me" is a syntactically valid interest name).
+    get 'interests/me', to: 'interests#me', as: :my_interests
+    put 'interests/me', to: 'interests#update_me'
+    get 'interests', to: 'interests#index', as: :interests
+    get 'interests/:name/tags', to: 'interests/tags#index', as: :interest_tags
+
     resources :followed_tags, only: [:index]
 
     resources :lists, only: [:index, :create, :show, :update, :destroy] do
@@ -320,6 +328,11 @@ namespace :api, format: false do
       patch 'accounts', to: 'accounts#update'
       delete 'accounts', to: 'accounts#destroy'
       resources :tokens, only: [:create]
+
+      post 'interests/bulk', to: 'interests#bulk'
+      get 'interests/:name/tags', to: 'interests#tags'
+      post 'interests', to: 'interests#create'
+      delete 'interests', to: 'interests#destroy'
     end
   end
 

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -43,6 +43,7 @@ namespace :api, format: false do
       resources :tag, only: :show
       post :tags, to: 'tags#show'
       resources :interest, only: :show
+      resource :interests, only: :show, controller: :interests
       resources :list, only: :show
     end
 

--- a/db/migrate/20260720120000_create_interests.rb
+++ b/db/migrate/20260720120000_create_interests.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class CreateInterests < ActiveRecord::Migration[8.0]
+  def change
+    create_table :interests do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+
+    add_index :interests, 'lower(name)', unique: true, name: :index_interests_on_name_lower
+
+    create_table :interest_tags do |t|
+      t.belongs_to :interest, null: false, foreign_key: { on_delete: :cascade }, index: false
+      t.belongs_to :tag, null: false, foreign_key: { on_delete: :cascade }
+
+      t.timestamps
+    end
+
+    add_index :interest_tags, [:interest_id, :tag_id], unique: true
+
+    create_table :account_interests do |t|
+      t.belongs_to :account, null: false, foreign_key: { on_delete: :cascade }, index: false
+      t.belongs_to :interest, null: false, foreign_key: { on_delete: :cascade }
+
+      t.timestamps
+    end
+
+    add_index :account_interests, [:account_id, :interest_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_13_123400) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_20_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -48,6 +48,15 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_13_123400) do
     t.datetime "updated_at", precision: nil, null: false
     t.bigint "account_id", null: false
     t.index ["account_id", "domain"], name: "index_account_domain_blocks_on_account_id_and_domain", unique: true
+  end
+
+  create_table "account_interests", force: :cascade do |t|
+    t.bigint "account_id", null: false
+    t.bigint "interest_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["account_id", "interest_id"], name: "index_account_interests_on_account_id_and_interest_id", unique: true
+    t.index ["interest_id"], name: "index_account_interests_on_interest_id"
   end
 
   create_table "account_migrations", force: :cascade do |t|
@@ -566,6 +575,22 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_13_123400) do
     t.datetime "data_updated_at", precision: nil
     t.bigint "account_id", null: false
     t.boolean "overwrite", default: false, null: false
+  end
+
+  create_table "interest_tags", force: :cascade do |t|
+    t.bigint "interest_id", null: false
+    t.bigint "tag_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["interest_id", "tag_id"], name: "index_interest_tags_on_interest_id_and_tag_id", unique: true
+    t.index ["tag_id"], name: "index_interest_tags_on_tag_id"
+  end
+
+  create_table "interests", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index "lower((name)::text)", name: "index_interests_on_name_lower", unique: true
   end
 
   create_table "invites", force: :cascade do |t|
@@ -1274,6 +1299,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_13_123400) do
   add_foreign_key "account_conversations", "conversations", on_delete: :cascade
   add_foreign_key "account_deletion_requests", "accounts", on_delete: :cascade
   add_foreign_key "account_domain_blocks", "accounts", name: "fk_206c6029bd", on_delete: :cascade
+  add_foreign_key "account_interests", "accounts", on_delete: :cascade
+  add_foreign_key "account_interests", "interests", on_delete: :cascade
   add_foreign_key "account_migrations", "accounts", column: "target_account_id", on_delete: :nullify
   add_foreign_key "account_migrations", "accounts", on_delete: :cascade
   add_foreign_key "account_moderation_notes", "accounts", column: "target_account_id", on_delete: :cascade
@@ -1330,6 +1357,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_13_123400) do
   add_foreign_key "generated_annual_reports", "accounts"
   add_foreign_key "identities", "users", name: "fk_bea040f377", on_delete: :cascade
   add_foreign_key "imports", "accounts", name: "fk_6db1b6e408", on_delete: :cascade
+  add_foreign_key "interest_tags", "interests", on_delete: :cascade
+  add_foreign_key "interest_tags", "tags", on_delete: :cascade
   add_foreign_key "invites", "users", on_delete: :cascade
   add_foreign_key "list_accounts", "accounts", on_delete: :cascade
   add_foreign_key "list_accounts", "follow_requests", on_delete: :cascade

--- a/lib/tasks/interests.rake
+++ b/lib/tasks/interests.rake
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+# One-off maintenance: reassign a curated set of hashtags to local root statuses.
+#
+# Input MAP is JSON, a list of { "question_id": "<status id>", "tags": ["tag", ...] }
+# (a { "<id>": ["tag", ...] } object is also accepted).
+#
+# For each local, non-reblog, non-reply status: the trailing hashtag-only block is
+# stripped from the text and replaced with the curated "#tag"s. statuses_tags is then
+# re-derived from the new text (via ProcessHashtagsService), featured_tags counts are
+# corrected, the fan-out cache is busted, and Elasticsearch is reindexed. No edit
+# marker is set (edited_at stays nil) and nothing is federated.
+#
+# Statuses are skipped and reported, never written, when they are remote, reblogs,
+# replies, have blank text, or still contain a hashtag in the body after the trailing
+# block is stripped ("leftover" — an inline tag or a non "\n\n" separator).
+#
+#   bin/rails interests:retag MAP=curated_tags.json DRY=1   # dry-run, prints diffs
+#   bin/rails interests:retag MAP=curated_tags.json         # apply
+
+module CuratedRetag
+  module_function
+
+  TAG_BLOCK_RE = /\A(?:\s*#\S+)+\s*\z/ # trailing segment: hashtags + whitespace only
+
+  def load_map(path)
+    raw  = JSON.parse(File.read(path))
+    rows = raw.is_a?(Array) ? raw : raw.map { |k, v| { 'question_id' => k, 'tags' => v } }
+    map  = Hash.new { |h, k| h[k] = [] }
+    rows.each { |r| map[r['question_id'].to_i].concat(Array(r['tags']).filter_map { |t| sanitize_tag(t) }) }
+    map.transform_values(&:uniq)
+  end
+
+  # space -> underscore (matches existing convention), strip anything Mastodon rejects, then validate.
+  def sanitize_tag(raw)
+    t = raw.to_s.strip.delete_prefix('#').gsub(/\s+/, '_').gsub(Tag::HASHTAG_INVALID_CHARS_RE, '')
+    t.match?(Tag::HASHTAG_NAME_RE) ? t : nil
+  end
+
+  def normalize_newlines(text)
+    text.to_s.gsub("\r\n", "\n").tr("\r", "\n")
+  end
+
+  def strip_tag_block(text)
+    return '' if text.match?(TAG_BLOCK_RE) # whole status is just a tag block (no body)
+
+    idx = text.rindex("\n\n")
+    return text.rstrip if idx.nil?
+
+    head = text[0...idx]
+    tail = text[(idx + 2)..] || ''
+    tail.match?(TAG_BLOCK_RE) ? head.rstrip : text.rstrip
+  end
+
+  def compose(body, tag_names)
+    b = body.strip
+    tags = tag_names.map { |t| "##{t}" }
+    return b if tags.empty?
+
+    b.empty? ? tags.join(' ') : "#{b}\n\n#{tags.join(' ')}"
+  end
+
+  def run(map_path, dry:, sample:)
+    map = load_map(map_path)
+    ids = map.keys
+    puts "loaded #{ids.size} questions from #{map_path}  (DRY=#{dry})"
+    no_tag = map.select { |_, v| v.empty? }.keys
+    puts "!! #{no_tag.size} rows have no valid tag after sanitize: #{no_tag.first(20).inspect}" if no_tag.any?
+
+    Chewy.strategy(:urgent) unless dry # rake context has no index strategy; sync ES writes on apply
+
+    counters = Hash.new { |h, k| h[k] = [] }
+    errors   = []
+    printed  = 0
+
+    counters[:missing] = ids - Status.where(id: ids).pluck(:id)
+
+    Status.where(id: ids).find_each(batch_size: 200) do |status|
+      raw_tags = map[status.id]
+      next if raw_tags.empty?
+
+      result = outcome_for(status, raw_tags)
+
+      if result.is_a?(Symbol) # skip reason or :unchanged
+        counters[result] << status.id
+      elsif dry
+        printed = preview(status, result, printed, sample)
+        counters[:changed] << status.id
+      else
+        apply_change(status, result, counters, errors)
+      end
+    end
+
+    report(counters, errors)
+    finalize(counters[:changed], dry)
+  end
+
+  # Returns a skip-reason/:unchanged Symbol, or the composed new text (String) for a change.
+  def outcome_for(status, raw_tags)
+    return :nonlocal unless status.local?
+    return :reblog if status.reblog?
+    return :reply if status.in_reply_to_id
+    return :blank if status.text.blank?
+
+    body = strip_tag_block(normalize_newlines(status.text))
+    return :leftover if Extractor.extract_hashtags(body).present? # inline tag / non "\n\n" separator
+
+    new_text = compose(body, raw_tags)
+    new_text == status.text ? :unchanged : new_text
+  end
+
+  def preview(status, new_text, printed, sample)
+    return printed unless sample.zero? || printed < sample
+
+    puts "\n--- ##{status.id} ---\nOLD: #{status.text.inspect}\nNEW: #{new_text.inspect}"
+    printed + 1
+  end
+
+  def apply_change(status, new_text, counters, errors)
+    ApplicationRecord.transaction do
+      status.text = new_text
+      status.save!
+      ProcessHashtagsService.new.call(status)
+    end
+    Rails.cache.delete("fan-out/#{status.id}")
+    counters[:changed] << status.id
+  rescue => e
+    errors << [status.id, e.class.name, e.message]
+  end
+
+  def finalize(changed_ids, dry)
+    if dry
+      puts "\nDRY run — nothing written. Review 'leftover' + 'nonlocal' + 'reply' lists before applying."
+    elsif Chewy.enabled?
+      changed_ids.each_slice(500) do |slice|
+        scope = Status.where(id: slice)
+        StatusesIndex.import(scope)
+        PublicStatusesIndex.import(scope)
+      end
+      puts "ES reindexed #{changed_ids.size} statuses"
+    else
+      puts 'ES disabled — no reindex'
+    end
+  end
+
+  def report(counters, errors)
+    puts "\nsummary:"
+    %i(changed unchanged missing nonlocal reblog reply blank leftover).each do |k|
+      puts "  #{k.to_s.ljust(9)} #{counters[k].size}"
+    end
+    puts "  errors    #{errors.size}"
+    %i(missing nonlocal reblog reply blank leftover).each do |k|
+      puts "  #{k}: #{counters[k].first(50).inspect}" if counters[k].any?
+    end
+    errors.first(50).each { |id, kl, m| puts "ERROR ##{id}: #{kl}: #{m}" }
+  end
+end
+
+namespace :interests do
+  desc 'Reassign curated hashtags to local root statuses (MAP=path.json [DRY=1] [SAMPLE=n])'
+  task retag: :environment do
+    map_path = ENV.fetch('MAP')
+    dry      = ENV['DRY'] == '1'
+    sample   = (ENV['SAMPLE'] || (dry ? '20' : '0')).to_i
+    CuratedRetag.run(map_path, dry: dry, sample: sample)
+  end
+end

--- a/spec/fabricators/account_interest_fabricator.rb
+++ b/spec/fabricators/account_interest_fabricator.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+Fabricator(:account_interest) do
+  account { Fabricate.build(:account) }
+  interest
+end

--- a/spec/fabricators/interest_fabricator.rb
+++ b/spec/fabricators/interest_fabricator.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Fabricator(:interest) do
+  name { sequence(:interest) { |i| "#{Faker::Lorem.word}#{i}" } }
+end

--- a/spec/fabricators/interest_tag_fabricator.rb
+++ b/spec/fabricators/interest_tag_fabricator.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+Fabricator(:interest_tag) do
+  interest
+  tag { Fabricate.build(:tag) }
+end

--- a/spec/models/tags_feed_spec.rb
+++ b/spec/models/tags_feed_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe TagsFeed do
+  subject { described_class.new(tag_names, account, options) }
+
+  let(:account)     { Fabricate(:account) }
+  let(:options)     { {} }
+  let(:tag_names)   { %w(life love) }
+
+  let!(:life_status) { PostStatusService.new.call(account, text: 'my #life') }
+  let!(:love_status) { PostStatusService.new.call(account, text: 'what is #love?') }
+
+  before { PostStatusService.new.call(account, text: '#war never changes') }
+
+  describe '#get' do
+    it 'returns the union of the named tags, excluding others' do
+      expect(subject.get(20).map(&:id)).to contain_exactly(life_status.id, love_status.id)
+    end
+
+    context 'with pre-resolved tag ids' do
+      let(:tag_names) { nil }
+      let(:options)   { { tag_ids: Tag.matching_name(%w(life love)).pluck(:id) } }
+
+      it 'returns exactly what the name-based lookup returns' do
+        expect(subject.get(20).map(&:id))
+          .to eq(described_class.new(%w(life love), account).get(20).map(&:id))
+      end
+
+      it 'does not query tags by name' do
+        feed          = subject # resolve the ids outside the measured block
+        names_queried = false
+
+        subscriber = ActiveSupport::Notifications.subscribe('sql.active_record') do |_, _, _, _, payload|
+          names_queried ||= payload[:sql].include?('FROM "tags"')
+        end
+
+        feed.get(20)
+
+        expect(names_queried).to be(false)
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/interests/tags_spec.rb
+++ b/spec/requests/api/v1/interests/tags_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Interest tags' do
+  let(:user)    { Fabricate(:user) }
+  let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: 'read') }
+  let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
+
+  let(:interest) { Fabricate(:interest, name: 'politics') }
+
+  describe 'GET /api/v1/interests/:name/tags' do
+    subject { get "/api/v1/interests/#{name}/tags", params: params, headers: headers }
+
+    let(:name)   { 'politics' }
+    let(:params) { {} }
+
+    context 'when the interest has tags' do
+      before do
+        %w(election parliament vote).each do |tag_name|
+          Fabricate(:interest_tag, interest: interest, tag: Fabricate(:tag, name: tag_name))
+        end
+      end
+
+      it 'returns every tag', :aggregate_failures do
+        subject
+
+        expect(response).to have_http_status(200)
+        expect(response.content_type).to start_with('application/json')
+        expect(response.parsed_body.pluck(:name)).to match_array(%w(election parliament vote))
+      end
+
+      context 'with a limit' do
+        let(:params) { { limit: 2 } }
+
+        it 'paginates and sets a Link header', :aggregate_failures do
+          subject
+
+          expect(response.parsed_body.size).to eq(2)
+          expect(response.headers['Link']).to be_present
+        end
+      end
+    end
+
+    context 'when the interest has no tags' do
+      before { interest }
+
+      it 'returns an empty array', :aggregate_failures do
+        subject
+
+        expect(response).to have_http_status(200)
+        expect(response.parsed_body).to eq([])
+      end
+    end
+
+    context 'when the interest does not exist' do
+      let(:name) { 'nonexistent' }
+
+      it 'returns http not found' do
+        subject
+
+        expect(response).to have_http_status(404)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/interests_spec.rb
+++ b/spec/requests/api/v1/interests_spec.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Interests' do
+  let(:user)    { Fabricate(:user) }
+  let(:scopes)  { 'read write' }
+  let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
+  let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
+
+  let(:account)  { Fabricate(:account) }
+  let(:politics) { Fabricate(:interest, name: 'politics') }
+  let(:sports)   { Fabricate(:interest, name: 'sports') }
+  let(:cooking)  { Fabricate(:interest, name: 'cooking') }
+
+  # politics gets the most recent status, sports an older one, cooking none
+  def seed_interests!
+    old_status = PostStatusService.new.call(account, text: 'the #football match')
+    new_status = PostStatusService.new.call(account, text: 'the #election result')
+
+    Fabricate(:interest_tag, interest: sports, tag: new_status && Tag.find_normalized('football'))
+    Fabricate(:interest_tag, interest: politics, tag: Tag.find_normalized('election'))
+    cooking
+
+    [old_status, new_status]
+  end
+
+  def count_queries
+    count = 0
+
+    subscriber = ActiveSupport::Notifications.subscribe('sql.active_record') do |_, _, _, _, payload|
+      count += 1 unless %w(SCHEMA TRANSACTION).include?(payload[:name])
+    end
+
+    yield
+
+    count
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscriber)
+  end
+
+  describe 'GET /api/v1/interests' do
+    subject { get '/api/v1/interests', headers: headers }
+
+    before { seed_interests! }
+
+    it 'returns interests ordered by recency with tagless ones last', :aggregate_failures do
+      subject
+
+      expect(response).to have_http_status(200)
+      expect(response.content_type).to start_with('application/json')
+      expect(response.parsed_body.pluck('name')).to eq(%w(politics sports cooking))
+      expect(response.parsed_body.pluck('tags_count')).to eq([1, 1, 0])
+      expect(response.parsed_body.last['last_status_at']).to be_nil
+      expect(response.parsed_body.first['last_status_at']).to be_present
+    end
+
+    # Guards the presenter: serializing N interests must not become N+1.
+    it 'does not issue more queries as interests are added' do
+      get '/api/v1/interests', headers: headers # warm settings/permission caches
+      baseline = count_queries { get '/api/v1/interests', headers: headers }
+
+      5.times { |i| Fabricate(:interest, name: "extra#{i}") }
+
+      expect(count_queries { get '/api/v1/interests', headers: headers }).to eq(baseline)
+    end
+  end
+
+  describe 'GET /api/v1/interests/me' do
+    subject { get '/api/v1/interests/me', headers: headers }
+
+    before { Fabricate(:account_interest, account: user.account, interest: politics) }
+
+    it 'returns only the account interests', :aggregate_failures do
+      sports
+
+      subject
+
+      expect(response).to have_http_status(200)
+      expect(response.parsed_body.pluck('name')).to eq(['politics'])
+    end
+
+    context 'without an authentication token' do
+      let(:headers) { {} }
+
+      it 'returns http unauthorized' do
+        subject
+
+        expect(response).to have_http_status(401)
+      end
+    end
+  end
+
+  describe 'PUT /api/v1/interests/me' do
+    subject { put '/api/v1/interests/me', params: params, headers: headers }
+
+    let(:params) { { interests: %w(politics sports) } }
+
+    before do
+      politics
+      sports
+      cooking
+    end
+
+    it 'replaces the whole set', :aggregate_failures do
+      Fabricate(:account_interest, account: user.account, interest: cooking)
+
+      subject
+
+      expect(response).to have_http_status(200)
+      expect(user.account.interests.reload.pluck(:name)).to match_array(%w(politics sports))
+    end
+
+    it 'is idempotent' do
+      subject
+
+      expect { put '/api/v1/interests/me', params: params, headers: headers }
+        .to_not(change { user.account.account_interests.reload.count })
+    end
+
+    context 'with an empty list' do
+      let(:params) { { interests: [] } }
+
+      it 'clears every interest' do
+        Fabricate(:account_interest, account: user.account, interest: politics)
+
+        subject
+
+        expect(user.account.interests.reload).to be_empty
+      end
+    end
+
+    context 'with a differently cased name' do
+      let(:params) { { interests: %w(Politics) } }
+
+      it 'resolves it' do
+        subject
+
+        expect(user.account.interests.reload.pluck(:name)).to eq(['politics'])
+      end
+    end
+
+    context 'with an unknown interest' do
+      let(:params) { { interests: %w(politics politcs) } }
+
+      it 'changes nothing and returns 422', :aggregate_failures do
+        Fabricate(:account_interest, account: user.account, interest: cooking)
+
+        subject
+
+        expect(response).to have_http_status(422)
+        expect(response.parsed_body['unknown']).to eq(['politcs'])
+        expect(user.account.interests.reload.pluck(:name)).to eq(['cooking'])
+      end
+    end
+
+    context 'with the wrong scope' do
+      let(:scopes) { 'read' }
+
+      it 'returns http forbidden' do
+        subject
+
+        expect(response).to have_http_status(403)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/internal/interests_spec.rb
+++ b/spec/requests/api/v1/internal/interests_spec.rb
@@ -1,0 +1,252 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Internal Interests API' do
+  let(:internal_token) { 'test-internal-token' }
+  let(:headers)        { { 'X-Internal-Token' => internal_token } }
+
+  before do
+    allow(ENV).to receive(:fetch).and_call_original
+    allow(ENV).to receive(:fetch).with('INTERNAL_API_TOKEN', nil).and_return(internal_token)
+  end
+
+  describe 'POST /api/v1/internal/interests' do
+    subject { post '/api/v1/internal/interests', params: params, headers: headers }
+
+    let(:params) { { interest: 'politics', tag: 'election' } }
+
+    context 'without a valid token' do
+      let(:headers) { { 'X-Internal-Token' => 'wrong' } }
+
+      it 'returns http unauthorized' do
+        subject
+
+        expect(response).to have_http_status(401)
+      end
+    end
+
+    context 'when the internal token is not configured' do
+      before do
+        allow(ENV).to receive(:fetch).with('INTERNAL_API_TOKEN', nil).and_return(nil)
+      end
+
+      it 'returns http service unavailable' do
+        subject
+
+        expect(response).to have_http_status(503)
+      end
+    end
+
+    context 'when neither the interest nor the tag exists' do
+      it 'creates both and assigns them', :aggregate_failures do
+        subject
+
+        expect(response).to have_http_status(201)
+        expect(response.parsed_body).to include(
+          'interest' => 'politics',
+          'tag' => 'election',
+          'interest_created' => true,
+          'tag_created' => true,
+          'assignment_created' => true
+        )
+        expect(Interest.find_normalized('politics').tags.pluck(:name)).to eq(['election'])
+      end
+    end
+
+    context 'when the tag already exists' do
+      before { Fabricate(:tag, name: 'election') }
+
+      it 'does not report the tag as created' do
+        subject
+
+        expect(response.parsed_body['tag_created']).to be(false)
+      end
+    end
+
+    context 'when the assignment already exists' do
+      before { post '/api/v1/internal/interests', params: params, headers: headers }
+
+      it 'is idempotent', :aggregate_failures do
+        subject
+
+        expect(response).to have_http_status(200)
+        expect(response.parsed_body['assignment_created']).to be(false)
+        expect(InterestTag.count).to eq(1)
+      end
+    end
+
+    context 'with an invalid tag name' do
+      let(:params) { { interest: 'politics', tag: 'not a tag!' } }
+
+      it 'returns 422 and creates nothing', :aggregate_failures do
+        subject
+
+        expect(response).to have_http_status(422)
+        expect(response.parsed_body['error']).to eq('Invalid tag name')
+        expect(Tag.count).to eq(0)
+        expect(Interest.count).to eq(0)
+      end
+    end
+
+    context 'with an invalid interest name' do
+      let(:params) { { interest: 'not an interest!', tag: 'election' } }
+
+      it 'returns 422 and creates nothing', :aggregate_failures do
+        subject
+
+        expect(response).to have_http_status(422)
+        expect(response.parsed_body['error']).to eq('Invalid interest name')
+        expect(Interest.count).to eq(0)
+      end
+    end
+
+    context 'with a differently cased interest name' do
+      before { post '/api/v1/internal/interests', params: { interest: 'Politics', tag: 'election' }, headers: headers }
+
+      it 'does not create a duplicate interest' do
+        subject
+
+        expect(Interest.count).to eq(1)
+      end
+    end
+  end
+
+  describe 'DELETE /api/v1/internal/interests' do
+    subject { delete '/api/v1/internal/interests', params: { interest: 'politics', tag: 'election' }, headers: headers }
+
+    context 'when the assignment exists' do
+      before { post '/api/v1/internal/interests', params: { interest: 'politics', tag: 'election' }, headers: headers }
+
+      it 'removes it but keeps the tag and interest', :aggregate_failures do
+        subject
+
+        expect(response).to have_http_status(200)
+        expect(response.parsed_body['deleted']).to be(true)
+        expect(InterestTag.count).to eq(0)
+        expect(Interest.count).to eq(1)
+        expect(Tag.count).to eq(1)
+      end
+    end
+
+    context 'when the assignment does not exist' do
+      it 'returns http success with deleted false', :aggregate_failures do
+        subject
+
+        expect(response).to have_http_status(200)
+        expect(response.parsed_body['deleted']).to be(false)
+      end
+    end
+  end
+
+  describe 'POST /api/v1/internal/interests/bulk' do
+    subject { post '/api/v1/internal/interests/bulk', params: { assignments: assignments }, headers: headers }
+
+    context 'with valid assignments' do
+      let(:assignments) do
+        [
+          { interest: 'politics', tag: 'election' },
+          { interest: 'politics', tag: 'parliament' },
+          { interest: 'sports', tag: 'football' },
+        ]
+      end
+
+      it 'creates every assignment', :aggregate_failures do
+        subject
+
+        expect(response).to have_http_status(200)
+        expect(response.parsed_body).to include(
+          'processed' => 3,
+          'assignments_created' => 3,
+          'interests_created' => 2,
+          'tags_created' => 3,
+          'errors' => []
+        )
+        expect(Interest.find_normalized('politics').tags.pluck(:name)).to match_array(%w(election parliament))
+      end
+    end
+
+    context 'with a duplicated assignment' do
+      let(:assignments) do
+        [
+          { interest: 'politics', tag: 'election' },
+          { interest: 'politics', tag: 'election' },
+        ]
+      end
+
+      it 'inserts it once' do
+        subject
+
+        expect(response.parsed_body['assignments_created']).to eq(1)
+      end
+    end
+
+    context 'with a partially invalid batch' do
+      let(:assignments) do
+        [
+          { interest: 'politics', tag: 'election' },
+          { interest: 'politics', tag: 'not a tag!' },
+          { interest: 'politics', tag: 'parliament' },
+        ]
+      end
+
+      it 'commits the valid rows and reports the invalid one', :aggregate_failures do
+        subject
+
+        expect(response).to have_http_status(200)
+        expect(response.parsed_body['assignments_created']).to eq(2)
+        expect(response.parsed_body['errors'].size).to eq(1)
+        expect(response.parsed_body['errors'].first).to include('index' => 1, 'error' => 'Invalid tag name')
+        expect(Interest.find_normalized('politics').tags.pluck(:name)).to match_array(%w(election parliament))
+      end
+    end
+
+    context 'with more than the maximum number of assignments' do
+      let(:assignments) { Array.new(1001) { |i| { interest: 'politics', tag: "tag#{i}" } } }
+
+      it 'returns http unprocessable entity' do
+        subject
+
+        expect(response).to have_http_status(422)
+      end
+    end
+
+    context 'when assignments is not an array' do
+      let(:assignments) { 'nope' }
+
+      it 'returns http unprocessable entity' do
+        subject
+
+        expect(response).to have_http_status(422)
+      end
+    end
+  end
+
+  describe 'GET /api/v1/internal/interests/:name/tags' do
+    subject { get '/api/v1/internal/interests/politics/tags', headers: headers }
+
+    context 'when the interest exists' do
+      before do
+        post '/api/v1/internal/interests/bulk',
+             params: { assignments: [{ interest: 'politics', tag: 'election' }, { interest: 'politics', tag: 'parliament' }] },
+             headers: headers
+      end
+
+      it 'returns every tag unpaginated', :aggregate_failures do
+        subject
+
+        expect(response).to have_http_status(200)
+        expect(response.parsed_body['tags_count']).to eq(2)
+        expect(response.parsed_body['tags']).to match_array(%w(election parliament))
+      end
+    end
+
+    context 'when the interest does not exist' do
+      it 'returns http not found' do
+        subject
+
+        expect(response).to have_http_status(404)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/timelines/interest_spec.rb
+++ b/spec/requests/api/v1/timelines/interest_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Interest timeline' do
+  let(:user)    { Fabricate(:user) }
+  let(:scopes)  { 'read:statuses' }
+  let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
+  let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
+
+  describe 'GET /api/v1/timelines/interest/:name' do
+    subject { get "/api/v1/timelines/interest/#{name}", params: params, headers: headers }
+
+    let(:account)         { Fabricate(:account) }
+    let!(:private_status) { PostStatusService.new.call(account, visibility: :private, text: '#life could be a dream') }
+    let!(:life_status)    { PostStatusService.new.call(account, text: 'tell me what is my #life without your #love') }
+    let!(:war_status)     { PostStatusService.new.call(user.account, text: '#war, war never changes') }
+    let!(:love_status)    { PostStatusService.new.call(account, text: 'what is #love?') }
+    let!(:peace_status)   { PostStatusService.new.call(account, text: 'give #peace a chance') }
+    let!(:hope_status)    { PostStatusService.new.call(account, text: 'a little #hope') }
+    let!(:joy_status)     { PostStatusService.new.call(account, text: 'pure #joy') }
+
+    let(:interest) { Fabricate(:interest, name: 'feelings') }
+    let(:name)     { 'feelings' }
+    let(:params)   { {} }
+
+    def assign(*tag_names)
+      tag_names.each { |tag_name| Fabricate(:interest_tag, interest: interest, tag: Tag.find_normalized(tag_name)) }
+    end
+
+    it_behaves_like 'forbidden for wrong scope', 'profile'
+
+    context 'when the interest has a single tag' do
+      before { assign('life') }
+
+      it 'returns the tagged statuses', :aggregate_failures do
+        subject
+
+        expect(response).to have_http_status(200)
+        expect(response.content_type).to start_with('application/json')
+        expect(response.parsed_body.pluck(:id))
+          .to contain_exactly(life_status.id.to_s)
+          .and not_include(private_status.id.to_s)
+      end
+    end
+
+    # The key regression against TagFeed::LIMIT_PER_MODE, which silently caps at 4.
+    context 'when the interest has more than four tags' do
+      before { assign('life', 'love', 'war', 'peace', 'hope', 'joy') }
+
+      it 'returns statuses for every tag' do
+        subject
+
+        expect(response.parsed_body.pluck(:id))
+          .to match_array([life_status, love_status, war_status, peace_status, hope_status, joy_status].map { |status| status.id.to_s })
+      end
+    end
+
+    context 'when the interest has no tags' do
+      before { interest }
+
+      it 'returns an empty array', :aggregate_failures do
+        subject
+
+        expect(response).to have_http_status(200)
+        expect(response.parsed_body).to eq([])
+      end
+    end
+
+    context 'when the interest does not exist' do
+      let(:name) { 'nonexistent' }
+
+      it 'returns http not found' do
+        subject
+
+        expect(response).to have_http_status(404)
+      end
+    end
+
+    context 'with limit param' do
+      let(:params) { { limit: 1 } }
+
+      before { assign('life', 'love') }
+
+      it 'returns one status and a Link header', :aggregate_failures do
+        subject
+
+        expect(response.parsed_body.size).to eq(1)
+        expect(response.headers['Link']).to be_present
+      end
+    end
+
+    context 'with max_id param' do
+      let(:params) { { max_id: love_status.id } }
+
+      before { assign('life', 'love') }
+
+      it 'returns only statuses older than max_id', :aggregate_failures do
+        subject
+
+        ids = response.parsed_body.pluck(:id)
+        expect(ids).to include(life_status.id.to_s)
+        expect(ids).to_not include(love_status.id.to_s)
+      end
+    end
+
+    context 'when the instance does not allow public preview' do
+      before do
+        assign('life')
+        Form::AdminSettings.new(timeline_preview: false).save
+      end
+
+      context 'without an authentication token' do
+        let(:headers) { {} }
+
+        it 'returns http unprocessable entity' do
+          subject
+
+          expect(response).to have_http_status(422)
+        end
+      end
+
+      context 'when the user is authenticated' do
+        it 'returns the tagged statuses' do
+          subject
+
+          expect(response.parsed_body.pluck(:id)).to eq([life_status.id.to_s])
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/timelines/interests_spec.rb
+++ b/spec/requests/api/v1/timelines/interests_spec.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Personal interest timeline' do
+  let(:user)    { Fabricate(:user) }
+  let(:scopes)  { 'read:statuses' }
+  let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
+  let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
+
+  describe 'GET /api/v1/timelines/interests' do
+    subject { get '/api/v1/timelines/interests', params: params, headers: headers }
+
+    let(:author)          { Fabricate(:account) }
+    let!(:private_status) { PostStatusService.new.call(author, visibility: :private, text: '#life could be a dream') }
+    let!(:life_status)    { PostStatusService.new.call(author, text: 'tell me what is my #life without your #love') }
+    let!(:war_status)     { PostStatusService.new.call(author, text: '#war, war never changes') }
+    let!(:love_status)    { PostStatusService.new.call(author, text: 'what is #love?') }
+    let!(:peace_status)   { PostStatusService.new.call(author, text: 'give #peace a chance') }
+    let!(:hope_status)    { PostStatusService.new.call(author, text: 'a little #hope') }
+    let!(:joy_status)     { PostStatusService.new.call(author, text: 'pure #joy') }
+
+    let(:feelings) { Fabricate(:interest, name: 'feelings') }
+    let(:conflict) { Fabricate(:interest, name: 'conflict') }
+    let(:params)   { {} }
+
+    def assign(interest, *tag_names)
+      tag_names.each { |tag_name| Fabricate(:interest_tag, interest: interest, tag: Tag.find_normalized(tag_name)) }
+    end
+
+    def select_interests(*interests)
+      interests.each { |interest| Fabricate(:account_interest, account: user.account, interest: interest) }
+    end
+
+    it_behaves_like 'forbidden for wrong scope', 'profile'
+
+    context 'when the account has interests' do
+      before do
+        assign(feelings, 'life', 'love', 'hope', 'joy', 'peace')
+        assign(conflict, 'war')
+        select_interests(feelings, conflict)
+      end
+
+      it 'returns the union across every selected interest, more than four tags honored', :aggregate_failures do
+        subject
+
+        expect(response).to have_http_status(200)
+        expect(response.content_type).to start_with('application/json')
+        expect(response.parsed_body.pluck(:id))
+          .to match_array([life_status, love_status, hope_status, joy_status, peace_status, war_status].map { |status| status.id.to_s })
+          .and not_include(private_status.id.to_s)
+      end
+    end
+
+    context 'when a status matches tags from two different selected interests' do
+      before do
+        # #love is in feelings, and we also drop it into conflict so love_status is double-tagged
+        assign(feelings, 'love')
+        assign(conflict, 'love', 'war')
+        select_interests(feelings, conflict)
+      end
+
+      it 'returns that status only once' do
+        subject
+
+        expect(response.parsed_body.pluck(:id).count(love_status.id.to_s)).to eq(1)
+      end
+    end
+
+    context 'when the account has no interests' do
+      it 'returns an empty array', :aggregate_failures do
+        subject
+
+        expect(response).to have_http_status(200)
+        expect(response.parsed_body).to eq([])
+      end
+    end
+
+    context 'when the account has an interest with no tags' do
+      before { select_interests(feelings) }
+
+      it 'returns an empty array' do
+        subject
+
+        expect(response.parsed_body).to eq([])
+      end
+    end
+
+    context 'with limit param' do
+      let(:params) { { limit: 1 } }
+
+      before do
+        assign(feelings, 'life', 'love')
+        select_interests(feelings)
+      end
+
+      it 'returns one status and a Link header', :aggregate_failures do
+        subject
+
+        expect(response.parsed_body.size).to eq(1)
+        expect(response.headers['Link']).to be_present
+      end
+    end
+
+    context 'with max_id param' do
+      let(:params) { { max_id: love_status.id } }
+
+      before do
+        assign(feelings, 'life', 'love')
+        select_interests(feelings)
+      end
+
+      it 'returns only statuses older than max_id', :aggregate_failures do
+        subject
+
+        ids = response.parsed_body.pluck(:id)
+        expect(ids).to include(life_status.id.to_s)
+        expect(ids).to_not include(love_status.id.to_s)
+      end
+    end
+
+    context 'when an author is blocked' do
+      before do
+        assign(feelings, 'life')
+        select_interests(feelings)
+        user.account.block!(author)
+      end
+
+      it 'excludes the blocked author statuses' do
+        subject
+
+        expect(response.parsed_body.pluck(:id)).to_not include(life_status.id.to_s)
+      end
+    end
+
+    context 'without an authentication token' do
+      let(:headers) { {} }
+
+      it 'returns http unauthorized' do
+        subject
+
+        expect(response).to have_http_status(401)
+      end
+    end
+
+    # Unlike the per-interest timeline, this feed is always personal and must
+    # require a user even when the instance allows public preview.
+    context 'when the instance allows public preview but there is no token' do
+      let(:headers) { {} }
+
+      before { Form::AdminSettings.new(timeline_preview: true).save }
+
+      it 'still returns http unauthorized' do
+        subject
+
+        expect(response).to have_http_status(401)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Introduces **interests**: a server-owned, curated grouping of hashtags. A tag belongs to 0..N interests; an account selects 0..N interests.

Replaces the pattern where the client hardcodes a tag list and calls `POST /api/v1/timelines/tags`. The groupings are curated by the AI classification service, shared across clients, and selectable per user.

Read side plus a **personal interest feed**: `GET /api/v1/timelines/interests` returns the union timeline of every tag in every interest the caller has selected, resolved live from the token — no Redis, no fan-out worker, no backfill. A brand-new account that just picked interests gets a populated feed on the first request.

The heavier home-feed *injection* (writing interest-tagged posts into the precomputed home ZSET) and the multi-interest timeline stay out of scope — research and blockers are recorded in the design doc appendices. The personal feed delivers the user-visible outcome of "new users get a feed" without that fan-out work.

## Schema

Three tables, following the `tag_follows` precedent: `interests` (unique on `lower(name)`), `interest_tags`, `account_interests`. Interest names are normalized with the same `HashtagNormalizer` tags use.

## Endpoints

| Method | Path | Auth |
|---|---|---|
| GET | `/api/v1/interests` | public |
| GET | `/api/v1/interests/:name/tags` | public, paginated |
| GET \| PUT | `/api/v1/interests/me` | `read:accounts` / `write:accounts` |
| GET | `/api/v1/timelines/interest/:name` | matches tag timeline |
| GET | `/api/v1/timelines/interests` | required (personal feed) |
| POST \| DELETE | `/api/v1/internal/interests` | `X-Internal-Token` |
| POST | `/api/v1/internal/interests/bulk` | `X-Internal-Token`, max 1000 |
| GET | `/api/v1/internal/interests/:name/tags` | `X-Internal-Token`, unpaginated |

Routed on name, not id — same as `Api::V1::TagsController#set_or_create_tag`, which treats `params[:id]` as a tag name. Numeric ids still appear in response bodies.

## Notable decisions

**Recency without scanning statuses.** `tags.last_status_at` is unusable: it is written in one place (`app/lib/activitypub/activity/create.rb`), for remote statuses only, throttled to once per 12 hours. Locally authored posts never update it. Instead recency comes from `MAX(statuses_tags.status_id)` — Snowflake ids are monotonic in time. A `CROSS JOIN LATERAL ... LIMIT 1` makes each `interest_tags` row a single backwards index seek against the `(tag_id, status_id)` primary key, so cost is bounded by taxonomy size rather than status count, and the `statuses` table is never touched.

**Validation runs on raw input, not normalized.** `HashtagNormalizer` strips invalid characters, so validating after normalizing means `"not a tag!"` becomes a valid `"notatag"` and nothing is ever rejected. This also has to happen before any create: `Tag.find_or_create_by_names` uses `create`, not `create!`, so an invalid name silently returns an unpersisted record whose `nil` id would then violate `interest_tags.tag_id NOT NULL`.

**Bulk is not transactional.** One malformed name must not roll back 999 valid rows. Failures are reported per index and valid rows commit.

**`PUT /interests/me` is all-or-nothing.** Interests are server-curated and the client fetches them from `GET /interests`, so an unknown name is always a client bug — silently dropping it would hide that.

**The timeline stays a GET.** The multi-tag endpoint had to become a POST because it echoed dozens of tag names into the pagination `Link` header, overflowing nginx's 4 KB `proxy_buffer_size`. One short name in the URL keeps the header small — measured **1215 bytes** against the 5824 that produced the 502 — so standard server-driven pagination keeps working.

**`TagsFeed` gained a `tag_ids:` option** (3 lines, backwards compatible). An interest already holds tag ids; passing names would pluck them only to look the same ids back up. No new feed class — the same option powers both the per-interest and the personal timeline.

**Personal feed is a live query, not a fan-out.** The home timeline is a precomputed Redis ZSET written at post time, and Mastodon has no merge worker to retroactively pull old posts in — so a freshly onboarded account would see an empty home feed. `GET /timelines/interests` instead resolves the account's interests to tag ids and queries them directly through `TagsFeed`. It stays a GET because tags come from the token, not the URL, so the `Link` header stays small (measured **1205 bytes**). Reusing `TagsFeed` means a status matching several of the account's tags is de-duplicated (`group(:id)`) and block/mute filtering (`PublicFeed#account_filters_scope`) comes for free. Unlike the per-interest timeline it never allows public preview — it always requires a user.

## Testing

53 examples across six new spec files, plus live smoke tests on the Vagrant instance covering the full HTTP surface: seeding via bulk, recency ordering, `Link` header pagination, replace-set semantics, 422-with-no-change, idempotent internal writes, and Arabic interest names round-tripping through both public and internal paths. The personal feed was verified to return **byte-identical status ids** to the equivalent `POST /timelines/tags` call — proving it is just the token-driven form of the same query — with double-tagged statuses de-duplicated and blocked authors excluded.

One spec fails on the dev box — `timelines/interest_spec.rb:116` expects 422 without a token but gets 401. Environmental: this instance runs `limited_federation_mode`, so all unauthenticated API access 401s. Upstream `spec/requests/api/v1/timelines/tag_spec.rb` fails identically.

Rubocop clean across all touched files.